### PR TITLE
add specs for additional podfile control

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ export default {
 };
 ```
 
+### Optional: additional Podfile configuration
+
 [Podfiles](https://guides.cocoapods.org/using/the-podfile.html) can do a lot more than just pinning versions. If you want to specify a pod with a complete Podfile specification, you can do so by using the `specs` prop. For example, to specify a pod with a git source and branch: 
 
 **app.config.js**

--- a/README.md
+++ b/README.md
@@ -69,13 +69,34 @@ export default {
 };
 ```
 
+[Podfiles](https://guides.cocoapods.org/using/the-podfile.html) can do a lot more than just pinning versions. If you want to specify a pod with a complete Podfile specification, you can do so by using the `specs` prop. For example, to specify a pod with a git source and branch: 
+
+**app.config.js**
+```js
+export default {
+  ...
+  plugins: [
+      [
+        "expo-pod-pinner",
+        {
+          "targetName": "YourTargetName",
+          "specs": [
+            { "Alamofire": ":git => 'https://github.com/Alamofire/Alamofire.git', :branch => 'dev'" }
+          ]
+      }
+      ]
+  ]
+};
+```
+
 ### Plugin Props
 Configure the plugin using the following props in the plugin config object:
 
-| Prop        | Type   | Description                                                           |
-|-------------|--------|-----------------------------------------------------------------------|
-| `targetName`| string | The name of the target in your Podfile where the pods should be added.|
-| `pods`      | array  | An array of objects specifying the pod names and their versions.      |
+| Prop         | Type   | Description                                                                            |
+|--------------|--------|----------------------------------------------------------------------------------------|
+| `targetName` | string | The name of the target in your Podfile where the pods should be added.                 |
+| `pods`       | array  | An array of objects specifying the pod names and their versions.                       |
+| `specs`      | array  | An array of objects specifying the pod names and their complete Podfile specification. |
 
 ## Prebuild (optional)
 Prebuilding in Expo will result in the generation of the native runtime code for the project (and `ios` and `android` directories being built). By prebuilding, we automatically link and configure the native modules that have implemented CocoaPods, autolinking, and other config plugins. You can think of prebuild like a native code bundler.

--- a/support/helpers.ts
+++ b/support/helpers.ts
@@ -1,4 +1,4 @@
-import { PLUGIN_PROPS, isPodEntry } from "../types/types";
+import {PLUGIN_PROPS, isPodEntry, isSpecEntry} from "../types/types";
 
 export function validatePluginProps(props: any): void {
   // check the type of each property
@@ -8,6 +8,10 @@ export function validatePluginProps(props: any): void {
 
   if (props.pods && isPodEntry(props.pods)) {
     throw new Error("Expo Pod Pinner: 'pods' must be an object with string keys and string values.");
+  }
+
+  if (props.specs && isSpecEntry(props.specs)) {
+    throw new Error("Expo Pod Pinner: 'specs' must be an object with string keys and string values.");
   }
 
   // check for extra properties

--- a/support/updatePodfile.ts
+++ b/support/updatePodfile.ts
@@ -6,20 +6,15 @@ export async function updatePodfile(iosPath: string, props: PodPinnerPluginProps
   const podfileContent = await FileManager.readFile(`${iosPath}/Podfile`);
   let updatedPodfile = podfileContent;
 
-  props.pods.forEach((pod) => {
-    const podName = Object.keys(pod)[0];
-    const version = pod[podName];
-    const podDeclaration = `pod '${podName}', '${version}'`;
-    const podRegex = new RegExp(`pod\\s+'${podName}'\\s*,\\s*'([^']*)'`, 'g');
-
+  function addPodSpec(podRegex: RegExp, spec: string, podDeclaration: string, podName: string) {
     const match = podRegex.exec(updatedPodfile);
     if (match && match[1]) {
       // If the pod is already in the Podfile, check if the version needs updating.
-      if (match[1] !== version) {
+      if (match[1] !== spec) {
         updatedPodfile = updatedPodfile.replace(podRegex, podDeclaration);
         PodPinnerLog.log(`Updated version for ${podName} in Podfile.`);
       } else {
-        PodPinnerLog.log(`${podName} is already at version ${version} in Podfile. No update needed.`);
+        PodPinnerLog.log(`${podName} already has spec ${spec} in Podfile. No update needed.`);
       }
     } else {
       // If the pod isn't in the Podfile, add it under the specified target.
@@ -32,6 +27,21 @@ export async function updatePodfile(iosPath: string, props: PodPinnerPluginProps
         PodPinnerLog.error(`Target "${props.targetName}" not found in Podfile.`);
       }
     }
+  }
+
+  props.pods?.forEach((pod) => {
+    const podName = Object.keys(pod)[0];
+    const version = pod[podName];
+    const podDeclaration = `pod '${podName}', '${version}'`;
+    const podRegex = new RegExp(`pod\\s+'${podName}'\\s*,\\s*'([^']*)'`, 'g');
+    addPodSpec(podRegex, version, podDeclaration, podName);
+  });
+  props.specs?.forEach((pod) => {
+    const podName = Object.keys(pod)[0];
+    const spec = pod[podName];
+    const podDeclaration = `pod '${podName}', ${spec}`;
+    const podRegex = new RegExp(`pod\\s+'${podName}'\\s*,\\s*'([^']*)'`, 'g');
+    addPodSpec(podRegex, spec, podDeclaration, podName);
   });
 
   // Only write to the Podfile if changes have been made.

--- a/types/types.ts
+++ b/types/types.ts
@@ -1,5 +1,7 @@
 export type PodEntry = { [podName: string]: string };
 
+export type SpecEntry = { [podName: string]: string };
+
 export function isPodEntry(entry: any): entry is PodEntry {
   if (typeof entry !== "object") {
     return false;
@@ -14,12 +16,19 @@ export function isPodEntry(entry: any): entry is PodEntry {
   return true;
 }
 
+export function isSpecEntry(entry: any): entry is SpecEntry {
+  // Spec and Pod have the same types
+  return isPodEntry(entry);
+}
+
 export type PodPinnerPluginProps = {
   targetName: string;
-  pods: PodEntry[];
+  pods?: PodEntry[];
+  specs?: SpecEntry[];
 };
 
 export const PLUGIN_PROPS: string[] = [
   "targetName",
-  "pods"
+  "pods",
+  "specs",
 ];


### PR DESCRIPTION
# Description
## One Line Summary
Adds a new property to config called "specs" to allow full control over the Podfile output.

## Details

### Motivation
I needed to override a crappy okta ios library to fix their problems and I needed to do more than set the version. (Actually, that wouldn't have helped since there's another library pinning to the exact version.)

I found that the Podfile is able to use local paths, so using this plugin I was able to vendor changes and override to finally get auth working.

### Scope
Adds a new optional property to avoid breaking others. That's probably not the biggest concern for this plugin, but the original config was more succinct. Optionally, this could ask for single quotes in the version string but that seemed ugly.

# Testing

## Manual testing
**REQUIRED -** Explain what scenarios were tested and the environment.
Tested in our project.

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have personally tested this on my device, or explained why that is not possible
   - [ ] I have tested this on the latest version of the plugin (not sure how I'd do that?)
   - [x] I have tested this on both Android and iOS, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
